### PR TITLE
always pass array to pi_getFFvalue

### DIFF
--- a/Classes/Controller/Form.php
+++ b/Classes/Controller/Form.php
@@ -151,7 +151,7 @@ class Form extends AbstractController {
       $flexformSection = $option[1];
       $component = $option[2];
       $componentName = $option[3];
-      $value = $this->utilityFuncs->pi_getFFvalue($this->cObj->data['pi_flexform'], $fieldName, $flexformSection);
+      $value = $this->utilityFuncs->pi_getFFvalue($this->cObj->data['pi_flexform'] ?? [], $fieldName, $flexformSection);
 
       // Check if a Mail Finisher can be found in the config
       $isConfigOk = false;

--- a/Classes/Finisher/GenerateAuthCode.php
+++ b/Classes/Finisher/GenerateAuthCode.php
@@ -75,7 +75,7 @@ class GenerateAuthCode extends AbstractFinisher {
         if (isset($this->settings['authCodePage'])) {
           $authCodePage = $this->utilityFuncs->getSingle($this->settings, 'authCodePage');
         } else {
-          $authCodePage = $this->utilityFuncs->pi_getFFvalue($this->cObj->data['pi_flexform'], 'redirect_page', 'sMISC');
+          $authCodePage = $this->utilityFuncs->pi_getFFvalue($this->cObj->data['pi_flexform'] ?? [], 'redirect_page', 'sMISC');
         }
         if (!$authCodePage) {
           $authCodePage = $GLOBALS['TSFE']->id;

--- a/Classes/Finisher/Mail.php
+++ b/Classes/Finisher/Mail.php
@@ -181,7 +181,7 @@ class Mail extends AbstractFinisher {
       'langFile' => 'lang_file',
     ];
     foreach ($defaultOptions as $key => $option) {
-      $fileName = $this->utilityFuncs->pi_getFFvalue($this->cObj->data['pi_flexform'], $option);
+      $fileName = $this->utilityFuncs->pi_getFFvalue($this->cObj->data['pi_flexform'] ?? [], $option);
       if ($fileName) {
         $this->settings[$key] = $fileName;
       }

--- a/Classes/Finisher/Redirect.php
+++ b/Classes/Finisher/Redirect.php
@@ -35,7 +35,7 @@ class Redirect extends AbstractFinisher {
   public function init(array $gp, array $tsConfig): void {
     $this->gp = $gp;
     $this->settings = $tsConfig;
-    $redirect = $this->utilityFuncs->pi_getFFvalue($this->cObj->data['pi_flexform'], 'redirect_page', 'sMISC');
+    $redirect = $this->utilityFuncs->pi_getFFvalue($this->cObj->data['pi_flexform'] ?? [], 'redirect_page', 'sMISC');
     if ($redirect) {
       $this->settings['redirectPage'] = $redirect;
     }

--- a/Classes/Validator/DefaultValidator.php
+++ b/Classes/Validator/DefaultValidator.php
@@ -52,7 +52,7 @@ class DefaultValidator extends AbstractValidator {
   public function init(array $gp, array $tsConfig): void {
     $this->settings = $tsConfig;
 
-    $flexformValue = $this->utilityFuncs->pi_getFFvalue($this->cObj->data['pi_flexform'], 'required_fields', 'sMISC');
+    $flexformValue = $this->utilityFuncs->pi_getFFvalue($this->cObj->data['pi_flexform'] ?? [], 'required_fields', 'sMISC');
     if ($flexformValue) {
       $fields = GeneralUtility::trimExplode(',', $flexformValue);
 


### PR DESCRIPTION
A FlexForm is not always available and null may be passed to pi_getFFvalue, which expects an array, from various places. This patch passes [] is no FlexForm is defined and avoids a run-time error.