### PR TITLE
fix mail message initialization

### DIFF
--- a/Classes/Mailer/TYPO3Mailer.php
+++ b/Classes/Mailer/TYPO3Mailer.php
@@ -41,6 +41,11 @@ class TYPO3Mailer extends AbstractMailer implements MailerInterface {
     $this->emailObj = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(MailMessage::class);
   }
 
+  public function init(array $gp, array $settings): void {
+    parent::init($gp, $settings);
+    $this->emailObj = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(MailMessage::class);
+  }
+
   /* (non-PHPdoc)
    * @see Classes/Mailer/Tx_FormhandlerMailerInterface#addAttachment()
   */


### PR DESCRIPTION
When multiple mails are being sent (e.g. admin, user), TYPO3Mailer currently reuses the MailMessage instance. In effect, fields are not reset and headers such as CC are reused in additional mails.

This patch creates a new MailMessage instance after init is called. The additional initialization of emailObj in __construct is not removed to leave the constructor with the field initialized.