### PR TITLE
fix conditions without operator

### DIFF
--- a/Classes/Utility/GeneralUtility.php
+++ b/Classes/Utility/GeneralUtility.php
@@ -438,7 +438,7 @@ class GeneralUtility implements SingletonInterface {
       return $conditionResult;
     }
 
-    $conditionOperator = trim($valueConditions[1]);
+    $conditionOperator = trim($valueConditions[1] ?? '');
     $fieldName = trim($valueConditions[0]);
 
     switch ($conditionOperator) {


### PR DESCRIPTION
Do not try to access the operator if it does not exist to avoid a
run-time error.