### PR TITLE
[TASK] bring back the prefixID

### DIFF
--- a/Classes/Controller/Form.php
+++ b/Classes/Controller/Form.php
@@ -451,6 +451,7 @@ class Form extends AbstractController {
     $this->formValuesPrefix = $this->utilityFuncs->getSingle($this->settings, 'formValuesPrefix');
     $this->globals->setFormID($this->utilityFuncs->getSingle($this->settings, 'formID'));
     $this->globals->setFormValuesPrefix($this->formValuesPrefix);
+    $this->globals->setPrefixId($this->utilityFuncs->getSingle($this->settings, 'prefixId'));
 
     $isDebugMode = $this->utilityFuncs->getSingle($this->settings, 'debug');
     $this->debugMode = (1 === (int) $isDebugMode);

--- a/Classes/Utility/Globals.php
+++ b/Classes/Utility/Globals.php
@@ -40,7 +40,9 @@ class Globals implements SingletonInterface {
 
   protected static string $formValuesPrefix = '';
 
-  /** @var array<string, mixed> */
+  protected static string $prefixId = '';
+
+    /** @var array<string, mixed> */
   protected static array $gp = [];
 
   /** @var string[] */
@@ -75,6 +77,7 @@ class Globals implements SingletonInterface {
     self::$debuggers = [];
     self::$formID = '';
     self::$formValuesPrefix = '';
+    self::$prefixId = '';
     self::$gp = [];
     self::$langFiles = [];
     self::$overrideSettings = [];
@@ -109,6 +112,10 @@ class Globals implements SingletonInterface {
   public static function getFormValuesPrefix(): string {
     return self::$formValuesPrefix;
   }
+
+    public static function getPrefixId(): string {
+        return self::$prefixId;
+    }
 
   /**
    * @return array<string, mixed>
@@ -192,6 +199,10 @@ class Globals implements SingletonInterface {
   public static function setFormValuesPrefix(string $formValuesPrefix): void {
     self::$formValuesPrefix = $formValuesPrefix;
   }
+
+    public static function setPrefixId(string $prefixId): void {
+        self::$prefixId = $prefixId;
+    }
 
   /**
    * @param array<string, mixed> $gp

--- a/Classes/View/AbstractView.php
+++ b/Classes/View/AbstractView.php
@@ -28,6 +28,12 @@ use Typoheads\Formhandler\Utility\Globals;
  * An abstract view for Formhandler.
  */
 abstract class AbstractView extends AbstractPlugin {
+
+    /**
+     * The prefix id
+     */
+    public string $prefixId = 'Tx_Formhandler';
+
   /**
    * The Formhandler component manager.
    */

--- a/Classes/View/AbstractView.php
+++ b/Classes/View/AbstractView.php
@@ -31,8 +31,10 @@ abstract class AbstractView extends AbstractPlugin {
 
     /**
      * The prefix id
+     *
+     * @var string
      */
-    public string $prefixId = 'Tx_Formhandler';
+    public $prefixId = 'Tx_Formhandler';
 
   /**
    * The Formhandler component manager.

--- a/Classes/View/AbstractView.php
+++ b/Classes/View/AbstractView.php
@@ -29,13 +29,6 @@ use Typoheads\Formhandler\Utility\Globals;
  */
 abstract class AbstractView extends AbstractPlugin {
 
-    /**
-     * The prefix id
-     *
-     * @var string
-     */
-    public $prefixId = 'Tx_Formhandler';
-
   /**
    * The Formhandler component manager.
    */
@@ -111,6 +104,7 @@ abstract class AbstractView extends AbstractPlugin {
     $this->utilityFuncs = $utilityFuncs;
     $this->cObj = $this->globals->getCObj();
     $this->markerBasedTemplateService = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(MarkerBasedTemplateService::class);
+    $this->prefixId = $this->globals->getPrefixId();
     $this->pi_loadLL();
     $this->initializeView();
   }

--- a/pi1/class.tx_formhandler_pi1.php
+++ b/pi1/class.tx_formhandler_pi1.php
@@ -41,7 +41,6 @@ class tx_formhandler_pi1 extends AbstractPlugin {
    * @return string The content that is displayed on the website
    */
   public function main(string $content, array $conf): string {
-    $this->prefixId = 'tx_formhandler_pi1';
     $this->scriptRelPath = 'pi1/class.tx_formhandler_pi1.php';
     $this->extKey = 'formhandler';
 


### PR DESCRIPTION
hello, I would like to use this version of formhandler to update some older TYPO3 Installations. 
There are some old forms and the prefixId is used in the context of "$this->pi_wrapInBaseClass($content)" function, this is used [here](https://github.com/JAK0TA/formhandler/blob/b57d7c340540bdea34b0488db55e5f44d585f089/Classes/View/Form.php#L350) in the render() function. Here the prefixId is converted to a CSS class which is otherwise missing. I think especially for updates of older version this would be good. We used that css class a lot.

Best Regards and thanks for all the work and efforts to make formhandler compatible with TYPO3 11 and PHP8
Sven