### PR TITLE
Type and null checks

### DIFF
--- a/Classes/Controller/Form.php
+++ b/Classes/Controller/Form.php
@@ -185,13 +185,13 @@ class Form extends AbstractController {
 
           GeneralUtility::makeInstance(PageRenderer::class)->addCssFile(
             $file,
-            $fileOptions['alternate'] ? 'alternate stylesheet' : 'stylesheet',
-            $fileOptions['media'] ? $fileOptions['media'] : 'all',
-            $fileOptions['title'] ? $fileOptions['title'] : '',
+            boolval($fileOptions['alternate'] ?? false) ? 'alternate stylesheet' : 'stylesheet',
+            $fileOptions['media'] ?? 'all',
+            $fileOptions['title'] ?? '',
             empty($fileOptions['disableCompression']),
-            $fileOptions['forceOnTop'] ? true : false,
-            $fileOptions['allWrap'],
-            $fileOptions['excludeFromConcatenation'] ? true : false
+            boolval($fileOptions['forceOnTop'] ?? false),
+            $fileOptions['allWrap'] ?? '',
+            boolval($fileOptions['excludeFromConcatenation'] ?? false)
           );
         }
       }
@@ -254,11 +254,11 @@ class Form extends AbstractController {
 
           GeneralUtility::makeInstance(PageRenderer::class)->addJsFile(
             $file,
-            $fileOptions['type'] ? $fileOptions['type'] : 'text/javascript',
+            $fileOptions['type'] ?? 'text/javascript',
             empty($fileOptions['disableCompression']),
-            $fileOptions['forceOnTop'] ? true : false,
-            $fileOptions['allWrap'],
-            $fileOptions['excludeFromConcatenation'] ? true : false
+            boolval($fileOptions['forceOnTop'] ?? false),
+            $fileOptions['allWrap'] ?? '',
+            boolval($fileOptions['excludeFromConcatenation'] ?? false)
           );
         }
       }
@@ -279,11 +279,11 @@ class Form extends AbstractController {
 
           GeneralUtility::makeInstance(PageRenderer::class)->addJsFooterFile(
             $file,
-            $fileOptions['type'] ? $fileOptions['type'] : 'text/javascript',
+            $fileOptions['type'] ?? 'text/javascript',
             empty($fileOptions['disableCompression']),
-            $fileOptions['forceOnTop'] ? true : false,
-            $fileOptions['allWrap'],
-            $fileOptions['excludeFromConcatenation'] ? true : false
+            boolval($fileOptions['forceOnTop'] ?? false),
+            $fileOptions['allWrap'] ?? '',
+            boolval($fileOptions['excludeFromConcatenation'] ?? false)
           );
         }
       }

--- a/Classes/Utility/GeneralUtility.php
+++ b/Classes/Utility/GeneralUtility.php
@@ -989,7 +989,7 @@ class GeneralUtility implements SingletonInterface {
     $resourceFiles = [];
     if (!self::isValidCObject($resourceFile) && isset($settings[$key.'.']) && is_array($settings[$key.'.'])) {
       foreach ($settings[$key.'.'] as $idx => $file) {
-        if (false === strpos($idx, '.')) {
+        if (false === strpos(strval($idx), '.')) {
           $file = self::getSingle($settings[$key.'.'], $idx);
           $fileOptions = $settings[$key.'.'][$idx.'.'];
           $fileOptions['file'] = $file;


### PR DESCRIPTION
Fixes #73 and some PHP Warnings hidden by #73

See:
Undefined array key "alternate" in /var/www/public/typo3conf/ext/formhandler/Classes/Controller/Form.php line 188