### PR TITLE
[TASK] allows integration of CSS Files with EXT: syntax

### DIFF
--- a/Classes/Controller/Form.php
+++ b/Classes/Controller/Form.php
@@ -7,6 +7,7 @@ namespace Typoheads\Formhandler\Controller;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Page\PageRenderer;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\PathUtility;
 use Typoheads\Formhandler\AjaxHandler\AbstractAjaxHandler;
 use Typoheads\Formhandler\Debugger\AbstractDebugger;
 use Typoheads\Formhandler\Finisher\AbstractFinisher;
@@ -182,6 +183,7 @@ class Form extends AbstractController {
         $file = strval($fileOptions['file'] ?? '');
         if (strlen(trim($file)) > 0) {
           $file = $this->utilityFuncs->resolveRelPathFromSiteRoot($file);
+          $file = PathUtility::getAbsoluteWebPath($file);
 
           GeneralUtility::makeInstance(PageRenderer::class)->addCssFile(
             $file,


### PR DESCRIPTION
Hi,

if you integrate CSS Files in this way:


```
  cssFile {
    10 = TEXT
    10.value = EXT:my_sitepackage/Resources/Public/Css/ContactForm/File1.css

    20 = TEXT
    20.value = EXT:my_sitepackage/Resources/Public/Contrib/datepicker/datepicker.css

    30 = TEXT
    30.value = EXT:my_sitepackage/Resources/Public/Contrib/chosen/chosen.min.css
  }
```

you get file paths like this:

`<link rel="stylesheet" href="/var/www/html/public/typo3conf/ext/my_sitepackage/Resources/Public/Css/ContactForm/File1.css" media="all">`

so add a check after resolveRelPathFromSiteRoot() because this is only relevant for css files, resolveRelPathFromSiteRoot() checks also for Template and lang files