### PR TITLE
Fix mail embeds not working

### DIFF
--- a/Classes/Finisher/Mail.php
+++ b/Classes/Finisher/Mail.php
@@ -388,9 +388,9 @@ class Mail extends AbstractFinisher {
 
           $this->emailObj->embed($embedFile, $key, !empty($fileMime) ? $fileMime : null);
           $cids[$key] = "cid:{$key}";
+        } else {
+          $this->utilityFuncs->debugMessage('attachment_not_found', [$embedFile], 2);
         }
-
-        $this->utilityFuncs->debugMessage('attachment_not_found', [$embedFile], 2);
       }
     }
 

--- a/Classes/Finisher/Mail.php
+++ b/Classes/Finisher/Mail.php
@@ -376,18 +376,21 @@ class Mail extends AbstractFinisher {
     $cids = [];
     if (isset($settings['embedFiles.']) && is_array($settings['embedFiles.'])) {
       foreach ($settings['embedFiles.'] as $key => $embedFileSettings) {
-        if (false === strpos($key, '.')) {
-          $embedFile = $this->utilityFuncs->getSingle($settings['embedFiles.'], $key);
-          if (strlen($embedFile) > 0) {
-            if (!strstr($embedFile, $this->utilityFuncs->getDocumentRoot())) {
-              $embedFile = $this->utilityFuncs->getDocumentRoot().'/'.$embedFile;
-            }
-            $embedFile = $this->utilityFuncs->sanitizePath($embedFile);
-            $cids[$key] = $this->emailObj->embed($embedFile);
-          } else {
-            $this->utilityFuncs->debugMessage('attachment_not_found', [$embedFile], 2);
+        $key = rtrim($key, '.');
+        $embedFile = $this->utilityFuncs->getSingle($embedFileSettings, 'file');
+        $fileMime = $this->utilityFuncs->getSingle($embedFileSettings, 'mime');
+
+        if (!empty($embedFile)) {
+          if (!strstr($embedFile, $this->utilityFuncs->getDocumentRoot())) {
+            $embedFile = $this->utilityFuncs->getDocumentRoot().'/'.$embedFile;
           }
+          $embedFile = $this->utilityFuncs->sanitizePath($embedFile);
+
+          $this->emailObj->embed($embedFile, $key, !empty($fileMime) ? $fileMime : null);
+          $cids[$key] = "cid:{$key}";
         }
+
+        $this->utilityFuncs->debugMessage('attachment_not_found', [$embedFile], 2);
       }
     }
 

--- a/Classes/Mailer/MailerInterface.php
+++ b/Classes/Mailer/MailerInterface.php
@@ -55,7 +55,7 @@ interface MailerInterface {
    *
    * @param string $image The image path
    */
-  public function embed(string $image): Email;
+  public function embed(string $image, ?string $name = null, ?string $mime = null): Email;
 
   /**
    * Returns the BCC recipients of the email.

--- a/Classes/Mailer/TYPO3Mailer.php
+++ b/Classes/Mailer/TYPO3Mailer.php
@@ -41,11 +41,6 @@ class TYPO3Mailer extends AbstractMailer implements MailerInterface {
     $this->emailObj = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(MailMessage::class);
   }
 
-  public function init(array $gp, array $settings): void {
-    parent::init($gp, $settings);
-    $this->emailObj = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(MailMessage::class);
-  }
-
   /* (non-PHPdoc)
    * @see Classes/Mailer/Tx_FormhandlerMailerInterface#addAttachment()
   */
@@ -78,8 +73,8 @@ class TYPO3Mailer extends AbstractMailer implements MailerInterface {
     // TODO: Find a good way to make headers configurable
   }
 
-  public function embed(string $image): \Symfony\Component\Mime\Email {
-    return $this->emailObj->embedFromPath($image);
+  public function embed(string $image, ?string $name = null, ?string $mime = null): \Symfony\Component\Mime\Email {
+    return $this->emailObj->embedFromPath($image, $name, $mime);
   }
 
   /* (non-PHPdoc)
@@ -152,6 +147,11 @@ class TYPO3Mailer extends AbstractMailer implements MailerInterface {
   */
   public function getSubject(): string {
     return $this->emailObj->getSubject() ?? '';
+  }
+
+  public function init(array $gp, array $settings): void {
+    parent::init($gp, $settings);
+    $this->emailObj = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(MailMessage::class);
   }
 
   /* (non-PHPdoc)


### PR DESCRIPTION
The Symfony Mailers handling for embeds seems to have changed, requiring a name (for a cid) and returning the mail object instead of the cid.