### PR TITLE
Prevent double encoding of special characters

### DIFF
--- a/Classes/Interceptor/RemoveXSS.php
+++ b/Classes/Interceptor/RemoveXSS.php
@@ -117,7 +117,7 @@ class RemoveXSS extends AbstractInterceptor {
         if (!$isUTF8) {
           $value = utf8_encode($value);
         }
-        $value = htmlspecialchars($value, ENT_NOQUOTES | ENT_SUBSTITUTE | ENT_HTML401);
+        $value = htmlspecialchars($value, ENT_NOQUOTES | ENT_SUBSTITUTE | ENT_HTML401, null, false);
 
         if (!$isUTF8) {
           $value = utf8_decode($value);

--- a/Classes/Utility/GeneralUtility.php
+++ b/Classes/Utility/GeneralUtility.php
@@ -1217,12 +1217,12 @@ class GeneralUtility implements SingletonInterface {
             } else {
               $value = serialize($value);
             }
-            $value = htmlspecialchars($value);
+            $value = htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, null, false);
           }
         }
       }
     } else {
-      $values = htmlspecialchars($values);
+      $values = htmlspecialchars($values, ENT_QUOTES | ENT_SUBSTITUTE, null, false);
     }
 
     return $values;

--- a/Classes/View/Form.php
+++ b/Classes/View/Form.php
@@ -991,7 +991,7 @@ class Form extends AbstractView {
           $markers = array_merge($markers, $this->getSelectedMarkers($v, $level, $currPrefix));
           --$level;
         } else {
-          $v = htmlspecialchars(strval($v));
+          $v = htmlspecialchars(strval($v), ENT_QUOTES | ENT_SUBSTITUTE, null, false);
           $markers['###'.$currPrefix.'_'.$v.'###'] = $activeString;
           $markers['###'.strtoupper($currPrefix).'###'] = $markers['###'.$currPrefix.'_'.$v.'###'];
         }
@@ -1065,7 +1065,7 @@ class Form extends AbstractView {
         } else {
           if ($doEncode) {
             if (!in_array($k, $this->disableEncodingFields)) {
-              $v = htmlspecialchars(strval($v));
+              $v = htmlspecialchars(strval($v), ENT_QUOTES | ENT_SUBSTITUTE, null, false);
             }
           }
           $markers['###'.$currPrefix.'###'] = trim(strval($v));


### PR DESCRIPTION
fixes #116 

htmlspecialchars() by default tries to encode allready encoded characters again. setting "double_encode" to false prevents this.