### PR TITLE
Make string comparisons using ###if_ markers possible

### DIFF
--- a/Classes/Utility/GeneralUtility.php
+++ b/Classes/Utility/GeneralUtility.php
@@ -609,6 +609,10 @@ class GeneralUtility implements SingletonInterface {
       $value = '';
     }
 
+    if ('' === $value && in_array(substr($keyString, 0, 1), ['"', "'"]) && in_array(substr($keyString, -1, 1), ['"', "'"])) {
+      $value = $keyString;
+    }
+
     return $value;
   }
 


### PR DESCRIPTION
`###if_` conditions can only check against field- or global values. 
This change would make checking string values like `###if_'teststring' != 'secondTestString'###` possible, which would enable checkign if typoscript or language markers are set. (like `###if_'###ts_marker###' == 'someValue'###`)