### PR TITLE
Fix file validators not working correctly

### DIFF
--- a/Classes/Controller/Form.php
+++ b/Classes/Controller/Form.php
@@ -1160,6 +1160,11 @@ class Form extends AbstractController {
 
     $this->globals->setRandomID(strval($this->gp['randomID'] ?? ''));
 
+    // process files
+    if ($this->currentStep >= $this->lastStep) {
+      $this->processFiles();
+    }
+
     // run validation
     $this->errors = [];
     $valid = [true];
@@ -1204,11 +1209,6 @@ class Form extends AbstractController {
           }
         }
       }
-    }
-
-    // process files
-    if ($this->currentStep >= $this->lastStep) {
-      $this->processFiles();
     }
 
     // if form is valid

--- a/Classes/Validator/ErrorCheck/FileMinCount.php
+++ b/Classes/Validator/ErrorCheck/FileMinCount.php
@@ -28,7 +28,9 @@ class FileMinCount extends AbstractErrorCheck {
     $currentStep = intval($this->globals->getSession()?->get('currentStep') ?? 1);
     $lastStep = intval($this->globals->getSession()?->get('lastStep') ?? 1);
     $minCount = intval($this->utilityFuncs->getSingle((array) ($this->settings['params'] ?? []), 'minCount'));
-    if (isset($files[$this->formFieldName]) && is_array($files[$this->formFieldName]) && $currentStep > $lastStep) {
+    if (is_array($files[$this->formFieldName])
+            && $currentStep > $lastStep
+    ) {
       foreach ($_FILES as $idx => $info) {
         if (!is_array($info['name'][$this->formFieldName])) {
           $info['name'][$this->formFieldName] = [$info['name'][$this->formFieldName]];
@@ -40,9 +42,6 @@ class FileMinCount extends AbstractErrorCheck {
           $checkFailed = $this->getCheckFailed();
         }
       }
-    } elseif((!isset($files[$this->formFieldName]) || !is_array($files[$this->formFieldName])) && $minCount > 0) {
-      // No files for this field at all, at least 1 expected. Fail the check
-      return $this->getCheckFailed();
     }
 
     return $checkFailed;

--- a/Classes/Validator/ErrorCheck/FileMinCount.php
+++ b/Classes/Validator/ErrorCheck/FileMinCount.php
@@ -28,9 +28,7 @@ class FileMinCount extends AbstractErrorCheck {
     $currentStep = intval($this->globals->getSession()?->get('currentStep') ?? 1);
     $lastStep = intval($this->globals->getSession()?->get('lastStep') ?? 1);
     $minCount = intval($this->utilityFuncs->getSingle((array) ($this->settings['params'] ?? []), 'minCount'));
-    if (is_array($files[$this->formFieldName])
-            && $currentStep > $lastStep
-    ) {
+    if (isset($files[$this->formFieldName]) && is_array($files[$this->formFieldName]) && $currentStep > $lastStep) {
       foreach ($_FILES as $idx => $info) {
         if (!is_array($info['name'][$this->formFieldName])) {
           $info['name'][$this->formFieldName] = [$info['name'][$this->formFieldName]];
@@ -42,6 +40,9 @@ class FileMinCount extends AbstractErrorCheck {
           $checkFailed = $this->getCheckFailed();
         }
       }
+    } elseif((!isset($files[$this->formFieldName]) || !is_array($files[$this->formFieldName])) && $minCount > 0) {
+      // No files for this field at all, at least 1 expected. Fail the check
+      return $this->getCheckFailed();
     }
 
     return $checkFailed;


### PR DESCRIPTION
The FileMinCount validator currently does not work correctly.

One issue is that the validator will not fail even when the min count is set to 1 but no files have been uploaded. In that case the array offset `$files[$this->formFieldName]` does not exist, but the check still passes.

Another problem is that the validators are currently run before the file processing function (which stores the uploaded files in the session). That means that the validators are always working with either no files (in case it's the first submit) or old files (in case it's a subsequent submit).