### PR TITLE
Fix step back not working & validator returning wrong result

### DIFF
--- a/Classes/Controller/FormController.php
+++ b/Classes/Controller/FormController.php
@@ -402,12 +402,16 @@ class FormController extends ActionController {
       $this->processUploadedFiles();
 
       if ($this->validators()) {
-        // Check for last step before changing step count
-        $isLast = $this->formStepIsLast();
+        // Check if current step is the last one
+        $beforeStepChange = $this->formStepIsLast();
 
         $this->formStepChange();
 
-        if ($isLast) {
+        // Check again after changing the step
+        $afterStepChange = $this->formStepIsLast();
+
+        // check if this really was the final step. Back buttons wont work otherwise
+        if ($beforeStepChange && $afterStepChange) {
           $this->saveInterceptors();
           $this->loggers();
 

--- a/Classes/Validator/DefaultValidator.php
+++ b/Classes/Validator/DefaultValidator.php
@@ -33,8 +33,8 @@ class DefaultValidator extends AbstractValidator {
   /**
    * @param FieldModel[] $fields
    */
-  private function checkFields(FormModel &$formConfig, mixed $formValues, array $fields, string $fieldNameDots, string $fieldNameBrackets): bool {
-    $isValid = true;
+  private function checkFields(FormModel &$formConfig, mixed $formValues, array $fields, string $fieldNameDots, string $fieldNameBrackets, bool $passedIsValid = true): bool {
+    $isValid = $passedIsValid;
 
     foreach ($fields as $field) {
       $fieldNamePathDots = $fieldNameDots.'.'.$field->name;
@@ -74,7 +74,7 @@ class DefaultValidator extends AbstractValidator {
         }
       }
       if (!empty($field->fields)) {
-        $isValid = $this->checkFields($formConfig, $formValue ?? [], $field->fields, $fieldNamePathDots, $fieldNamePathBrackets);
+        $isValid = $this->checkFields($formConfig, $formValue ?? [], $field->fields, $fieldNamePathDots, $fieldNamePathBrackets, $isValid);
       }
     }
 


### PR DESCRIPTION
- "back"-buttons currently dont work right. Clicking one on the last form step still submits the form.
- The default validator returned the wrong results, thus still passing even when there are errors