### PR TITLE
Fix rootpath key not set

### DIFF
--- a/Classes/Utility/Utility.php
+++ b/Classes/Utility/Utility.php
@@ -207,7 +207,11 @@ class Utility implements SingletonInterface {
     $configurationManager = GeneralUtility::makeInstance(ConfigurationManager::class);
     $extbaseFrameworkConfiguration = $configurationManager->getConfiguration(ConfigurationManagerInterface::CONFIGURATION_TYPE_FRAMEWORK);
 
-    return $extbaseFrameworkConfiguration['view'];
+    return [
+      'templateRootPaths' => isset($extbaseFrameworkConfiguration['view']['templateRootPaths']) ? $extbaseFrameworkConfiguration['view']['templateRootPaths'] : [],
+      'layoutRootPaths' => isset($extbaseFrameworkConfiguration['view']['layoutRootPaths']) ? $extbaseFrameworkConfiguration['view']['layoutRootPaths'] : [],
+      'partialRootPaths' => isset($extbaseFrameworkConfiguration['view']['partialRootPaths']) ? $extbaseFrameworkConfiguration['view']['partialRootPaths'] : [],
+    ];
   }
 
   public static function prepareAndWhereString(string $andWhere): string {


### PR DESCRIPTION
The Mailfinisher can currently throw errors when at least one of the rootpaths (template, layout or partial) isnt set. This change guarantees that the array keys at least exist