### PR TITLE
Mailfinisher: Add ability to use markers in subject line

### DIFF
--- a/Classes/Finisher/MailFinisher.php
+++ b/Classes/Finisher/MailFinisher.php
@@ -241,7 +241,7 @@ class MailFinisher extends AbstractFinisher {
       $matchFound = true;
       $stackedFormValueVariable = $this->formConfig->formValues;
       foreach ($explodedMarker as $singleExplodedMarker) {
-        if (is_array($stackedFormValueVariable) && !array_key_exists($singleExplodedMarker, $stackedFormValueVariable)) {
+        if (!is_array($stackedFormValueVariable) || !array_key_exists($singleExplodedMarker, $stackedFormValueVariable)) {
           $matchFound = false;
 
           break;

--- a/Classes/Finisher/MailFinisher.php
+++ b/Classes/Finisher/MailFinisher.php
@@ -241,7 +241,7 @@ class MailFinisher extends AbstractFinisher {
       $matchFound = true;
       $stackedFormValueVariable = $this->formConfig->formValues;
       foreach ($explodedMarker as $singleExplodedMarker) {
-        if (!array_key_exists($singleExplodedMarker, $stackedFormValueVariable)) {
+        if (is_array($stackedFormValueVariable) && !array_key_exists($singleExplodedMarker, $stackedFormValueVariable)) {
           $matchFound = false;
 
           break;


### PR DESCRIPTION
This adds the ability to use markers like `{1.group.field}` in the subject line