### PR TITLE
Fix multiple reciever emails not working sometimes

### DIFF
--- a/Classes/Finisher/MailFinisher.php
+++ b/Classes/Finisher/MailFinisher.php
@@ -212,6 +212,8 @@ class MailFinisher extends AbstractFinisher {
 
     $recipientAddresses = array_unique(explode(',', $recipientAddresses));
     foreach ($recipientAddresses as $emailOrFieldName) {
+      $emailOrFieldName = trim($emailOrFieldName);
+
       if (GeneralUtility::validEmail($emailOrFieldName)) {
         $recipientAdded = true;
         $recipientAddressArray[] = new Address($emailOrFieldName);


### PR DESCRIPTION
`GeneralUtility::validEmail()` doesnt handle whitespace trimming. Emails with whitespaces like ` test@test.com` currently wont work because of that