### PR TITLE
Fix filerequired validator not working

### DIFF
--- a/Classes/Validator/ErrorCheck/FileRequired.php
+++ b/Classes/Validator/ErrorCheck/FileRequired.php
@@ -29,11 +29,12 @@ class FileRequired extends AbstractErrorCheck {
       if (!is_array($files['name'][$this->formFieldName])) {
         $files['name'][$this->formFieldName] = [$files['name'][$this->formFieldName]];
       }
-      if (is_array($files['name'][$this->formFieldName]) && !empty($files['name'][$this->formFieldName][0])) {
+      if (isset($files['name'][$this->formFieldName]) && is_array($files['name'][$this->formFieldName]) && !empty($files['name'][$this->formFieldName][0])) {
         $found = true;
       }
     }
-    if (!$found && !is_array($sessionFiles[$this->formFieldName]) && 0 === count((array) $sessionFiles[$this->formFieldName])) {
+
+    if (!$found && (empty($sessionFiles) || !isset($sessionFiles[$this->formFieldName]) || !is_array($sessionFiles[$this->formFieldName]) || 0 === count($sessionFiles[$this->formFieldName]))) {
       $checkFailed = $this->getCheckFailed();
     }
 


### PR DESCRIPTION
There were no checks if specific array keys exist before accessing them, thus errors were beeing thrown