### PR TITLE
Add turnstile interceptor

### DIFF
--- a/Classes/Domain/Model/Config/FormModel.php
+++ b/Classes/Domain/Model/Config/FormModel.php
@@ -335,6 +335,9 @@ use Typoheads\Formhandler\Utility\Utility;
 class FormModel {
   public MailModel $admin;
 
+  /** @var array<string, string> */
+  public array $captchaFieldValues = [];
+
   /** @var ConditionBlockModel[] */
   public array $conditionBlocks = [];
 

--- a/Classes/Domain/Model/Config/Interceptor/TurnstileCaptchaInterceptorModel.php
+++ b/Classes/Domain/Model/Config/Interceptor/TurnstileCaptchaInterceptorModel.php
@@ -15,10 +15,7 @@ namespace Typoheads\Formhandler\Domain\Model\Config\Interceptor;
 use Typoheads\Formhandler\Interceptor\TurnstileCaptchaInterceptor;
 
 class TurnstileCaptchaInterceptorModel extends AbstractInterceptorModel {
-  /**
-   * @param array<string, mixed> $settings
-   */
-  public function __construct(array $settings) {}
+  public function __construct() {}
 
   public function class(): string {
     return TurnstileCaptchaInterceptor::class;

--- a/Classes/Domain/Model/Config/Interceptor/TurnstileCaptchaInterceptorModel.php
+++ b/Classes/Domain/Model/Config/Interceptor/TurnstileCaptchaInterceptorModel.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of TYPO3 CMS-based extension "Formhandler" by JAKOTA.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ */
+
+namespace Typoheads\Formhandler\Domain\Model\Config\Interceptor;
+
+use Typoheads\Formhandler\Interceptor\TurnstileCaptchaInterceptor;
+
+class TurnstileCaptchaInterceptorModel extends AbstractInterceptorModel {
+  /**
+   * @param array<string, mixed> $settings
+   */
+  public function __construct(array $settings) {}
+
+  public function class(): string {
+    return TurnstileCaptchaInterceptor::class;
+  }
+}

--- a/Classes/Http/TurnstileVerifyRequester.php
+++ b/Classes/Http/TurnstileVerifyRequester.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+// This file is part of the TYPO3 CMS project. [...]
+
+namespace Typoheads\Formhandler\Http;
+
+use TYPO3\CMS\Core\Http\RequestFactory;
+
+final class TurnstileVerifyRequester {
+  private const API_URL = 'https://challenges.cloudflare.com/turnstile/v0/siteverify';
+
+  public function __construct(
+    private RequestFactory $requestFactory,
+  ) {}
+
+  /**
+   * @return array<string, mixed>
+   */
+  public function request(string $turnstilePrivateKey, string $captchaResponse, string $remoteIp): array {
+    $response = $this->requestFactory->request(
+      self::API_URL,
+      'POST',
+      [
+        'form_params' => [
+          'secret' => $turnstilePrivateKey,
+          'response' => $captchaResponse,
+          'remoteip' => $remoteIp,
+        ],
+      ],
+    );
+
+    if (200 !== $response->getStatusCode()) {
+      throw new \RuntimeException(
+        'Returned status code is '.$response->getStatusCode(),
+      );
+    }
+
+    if ('application/json' !== $response->getHeaderLine('Content-Type')) {
+      throw new \RuntimeException(
+        'The request did not return JSON data',
+      );
+    }
+
+    $content = $response->getBody()->getContents();
+
+    return json_decode($content, true, flags: JSON_THROW_ON_ERROR);
+  }
+}

--- a/Classes/Interceptor/AbstractInterceptor.php
+++ b/Classes/Interceptor/AbstractInterceptor.php
@@ -17,5 +17,5 @@ use Typoheads\Formhandler\Domain\Model\Config\FormModel;
 use Typoheads\Formhandler\Domain\Model\Config\Interceptor\AbstractInterceptorModel;
 
 abstract class AbstractInterceptor implements SingletonInterface {
-  abstract public function process(FormModel &$formConfig, AbstractInterceptorModel &$interceptorConfig): void;
+  abstract public function process(FormModel &$formConfig, AbstractInterceptorModel &$interceptorConfig): bool;
 }

--- a/Classes/Interceptor/TurnstileCaptchaInterceptor.php
+++ b/Classes/Interceptor/TurnstileCaptchaInterceptor.php
@@ -32,8 +32,8 @@ class TurnstileCaptchaInterceptor extends AbstractInterceptor {
 
     $extensionConfiguration = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get('formhandler');
 
-    $turnstilePrivateKey = isset($extensionConfiguration['turnstile']['privatekey']) ? $extensionConfiguration['turnstile']['privatekey'] : '';
-    $turnstileWidgetToken = isset($formConfig->captchaFieldValues['turnstile']) ? $formConfig->captchaFieldValues['turnstile'] : '';
+    $turnstilePrivateKey = $extensionConfiguration['turnstile']['privatekey'] ?? '';
+    $turnstileWidgetToken = $formConfig->captchaFieldValues['turnstile'] ?? '';
 
     try {
       $validationResult = $this->requestClient->request($turnstilePrivateKey, $turnstileWidgetToken, GeneralUtility::getIndpEnv('REMOTE_ADDR'));

--- a/Classes/Interceptor/TurnstileCaptchaInterceptor.php
+++ b/Classes/Interceptor/TurnstileCaptchaInterceptor.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of TYPO3 CMS-based extension "Formhandler" by JAKOTA.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ */
+
+namespace Typoheads\Formhandler\Interceptor;
+
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use Typoheads\Formhandler\Definitions\Severity;
+use Typoheads\Formhandler\Domain\Model\Config\FormModel;
+use Typoheads\Formhandler\Domain\Model\Config\Interceptor\AbstractInterceptorModel;
+use Typoheads\Formhandler\Domain\Model\Config\Interceptor\TurnstileCaptchaInterceptorModel;
+use Typoheads\Formhandler\Http\TurnstileVerifyRequester;
+
+class TurnstileCaptchaInterceptor extends AbstractInterceptor {
+  public function __construct(
+    private TurnstileVerifyRequester $requestClient
+  ) {}
+
+  public function process(FormModel &$formConfig, AbstractInterceptorModel &$interceptorConfig): bool {
+    if (!$interceptorConfig instanceof TurnstileCaptchaInterceptorModel) {
+      return false;
+    }
+
+    $extensionConfiguration = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get('formhandler');
+
+    $turnstilePrivateKey = isset($extensionConfiguration['turnstile']['privatekey']) ? $extensionConfiguration['turnstile']['privatekey'] : '';
+    $turnstileWidgetToken = isset($formConfig->captchaFieldValues['turnstile']) ? $formConfig->captchaFieldValues['turnstile'] : '';
+
+    try {
+      $validationResult = $this->requestClient->request($turnstilePrivateKey, $turnstileWidgetToken, GeneralUtility::getIndpEnv('REMOTE_ADDR'));
+
+      if (isset($validationResult['success']) && true === $validationResult['success']) {
+        return true;
+      }
+
+      $formConfig->formErrors[] = 'captcha_failed';
+
+      return false;
+    } catch (\Exception $error) {
+      $formConfig->formErrors[] = 'captcha_failed';
+      $formConfig->debugMessage('turnstile_captcha_failed', [$error->getMessage()], Severity::Error);
+
+      return false;
+    }
+  }
+}

--- a/Classes/ViewHelpers/GetTurnstileSitekeyViewHelper.php
+++ b/Classes/ViewHelpers/GetTurnstileSitekeyViewHelper.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of TYPO3 CMS-based extension "Formhandler" by JAKOTA.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ */
+
+namespace Typoheads\Formhandler\ViewHelpers;
+
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+
+final class GetTurnstileSitekeyViewHelper extends AbstractViewHelper {
+  public function render(): string {
+    $extensionConfiguration = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get('formhandler');
+
+    if (is_array($extensionConfiguration) && isset($extensionConfiguration['turnstile']) && is_array($extensionConfiguration['turnstile'])) {
+      return $extensionConfiguration['turnstile']['sitekey'];
+    }
+
+    return '';
+  }
+}

--- a/Resources/Private/Language/locallang_example_form.xlf
+++ b/Resources/Private/Language/locallang_example_form.xlf
@@ -10,6 +10,9 @@
       <trans-unit id="error_FormError_FileTotalSizeMax" resname="error_FormError_FileTotalSizeMax">
         <source>Please reduce file size, you total upload is bigger than the allowed max total size.</source>
       </trans-unit>
+      <trans-unit id="error_FormError_captcha_failed" resname="error_FormError_captcha_failed">
+        <source>The captcha validation failed. Please resubmit your data.</source>
+      </trans-unit>
       <trans-unit id="submit" resname="submit">
         <source>Send</source>
       </trans-unit>

--- a/Resources/Private/Partials/FormField/TurnstileCaptchaField.html
+++ b/Resources/Private/Partials/FormField/TurnstileCaptchaField.html
@@ -1,0 +1,7 @@
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" xmlns:formhandler="http://typo3.org/ns/Typoheads/Formhandler/ViewHelpers" data-namespace-typo3-fluid="true">
+  <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-namespace-typo3-fluid="true">
+    <div class="cf-turnstile" data-sitekey="{formhandler:getTurnstileSitekey()}" data-theme="light" data-response-field-name="captcha[turnstile]" data-action="{formConfig.formValuesPrefix}"></div>
+
+    <f:asset.script identifier="turnstileCaptcha" src="https://challenges.cloudflare.com/turnstile/v0/api.js" />
+  </html>
+</html>


### PR DESCRIPTION
Adds a turnstile captcha interceptor and example field.

Additional changes:
- saveInterceptors can now fail, setting a formerror.
- the formconfig now has a captchaFieldValues property, containing all captcha responses. (Should make adding new captchas like recaptcha easier)