### PR TITLE
Add email override Interceptor

### DIFF
--- a/Classes/Domain/Model/Config/Finisher/MailFinisherModel.php
+++ b/Classes/Domain/Model/Config/Finisher/MailFinisherModel.php
@@ -39,15 +39,19 @@ class MailFinisherModel extends AbstractFinisherModel {
   private Utility $utility;
 
   /**
-   * @param array<string, mixed> $settings
+   * @param array<string, mixed>                                                                                                                                                                                                                                                                                                                                                                                                                                                       $settings
+   * @param array{toEmail: string, subject: string, senderEmail: string, senderName: string, replyToEmail: string, replyToName: string, ccEmail: string, ccName: string, bccEmail: string, bccName: string, returnPath: string, templateMailHtml: string, templateMailText: string, attachments: array<string, array{fileOrField: string, mime: null|string, renameTo: null|string}>, embedFiles: array<string, array{fileOrField: string, mime: null|string, renameTo: null|string}>} $adminMailConfig
+   * @param array{toEmail: string, subject: string, senderEmail: string, senderName: string, replyToEmail: string, replyToName: string, ccEmail: string, ccName: string, bccEmail: string, bccName: string, returnPath: string, templateMailHtml: string, templateMailText: string, attachments: array<string, array{fileOrField: string, mime: null|string, renameTo: null|string}>, embedFiles: array<string, array{fileOrField: string, mime: null|string, renameTo: null|string}>} $userMailConfig
    */
   public function __construct(
     private readonly array $settings,
+    ?array $adminMailConfig = null,
+    ?array $userMailConfig = null,
   ) {
     $this->utility = GeneralUtility::makeInstance(Utility::class);
     $this->returns = filter_var($settings['returns'] ?? false, FILTER_VALIDATE_BOOLEAN);
-    $this->adminMailConfig = $this->parseEmailTypeSettings(isset($this->settings['admin']) && is_array($this->settings['admin']) ? $this->settings['admin'] : []);
-    $this->userMailConfig = $this->parseEmailTypeSettings(isset($this->settings['user']) && is_array($this->settings['user']) ? $this->settings['user'] : []);
+    $this->adminMailConfig = (null !== $adminMailConfig) ? $adminMailConfig : $this->parseEmailTypeSettings(isset($this->settings['admin']) && is_array($this->settings['admin']) ? $this->settings['admin'] : []);
+    $this->userMailConfig = (null !== $userMailConfig) ? $userMailConfig : $this->parseEmailTypeSettings(isset($this->settings['user']) && is_array($this->settings['user']) ? $this->settings['user'] : []);
   }
 
   public function class(): string {

--- a/Classes/Domain/Model/Config/Interceptor/EmailOverrideInterceptorConditionBlock.php
+++ b/Classes/Domain/Model/Config/Interceptor/EmailOverrideInterceptorConditionBlock.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of TYPO3 CMS-based extension "Formhandler" by JAKOTA.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ */
+
+namespace Typoheads\Formhandler\Domain\Model\Config\Interceptor;
+
+use Typoheads\Formhandler\Domain\Model\Config\GeneralOptions\ConditionBlockModel;
+
+class EmailOverrideInterceptorConditionBlock extends ConditionBlockModel {
+  /** @var array<string, array<string, string>> */
+  public readonly array $conditions;
+
+  /** @var array<string, array<string, string>> */
+  public readonly array $else;
+
+  /** @var array<string, array<string, string>> */
+  public readonly array $isTrue;
+
+  /**
+   * @param array<string, mixed> $settings
+   */
+  public function __construct(array $settings) {
+    $this->conditions = $settings['conditions'] ?? [];
+    $this->else = $settings['else'] ?? [];
+    $this->isTrue = $settings['isTrue'] ?? [];
+  }
+}

--- a/Classes/Domain/Model/Config/Interceptor/EmailOverrideInterceptorModel.php
+++ b/Classes/Domain/Model/Config/Interceptor/EmailOverrideInterceptorModel.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of TYPO3 CMS-based extension "Formhandler" by JAKOTA.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ */
+
+namespace Typoheads\Formhandler\Domain\Model\Config\Interceptor;
+
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use Typoheads\Formhandler\Interceptor\EmailOverrideInterceptor;
+
+class EmailOverrideInterceptorModel extends AbstractInterceptorModel {
+  /** @var array<EmailOverrideInterceptorConditionBlock> */
+  public readonly array $conditonBlocks;
+
+  /**
+   * @param array<mixed> $settings
+   */
+  public function __construct(array $settings) {
+    $this->conditonBlocks = $this->parseConfig($settings);
+  }
+
+  public function class(): string {
+    return EmailOverrideInterceptor::class;
+  }
+
+  /**
+   * @param array<mixed> $settings
+   *
+   * @return array<EmailOverrideInterceptorConditionBlock>
+   */
+  protected function parseConfig(array $settings): array {
+    if (!is_array($settings)) {
+      return [];
+    }
+
+    $conditionBlocks = [];
+
+    foreach ($settings ?? [] as $conditionBlock) {
+      if (!isset($conditionBlock['conditions']) || (!isset($conditionBlock['isTrue']) && !isset($conditionBlock['else']))) {
+        continue;
+      }
+
+      $conditionBlocks[] = GeneralUtility::makeInstance(EmailOverrideInterceptorConditionBlock::class, $conditionBlock);
+    }
+
+    return $conditionBlocks;
+  }
+}

--- a/Classes/Domain/Model/Config/Interceptor/EmailOverrideInterceptorModel.php
+++ b/Classes/Domain/Model/Config/Interceptor/EmailOverrideInterceptorModel.php
@@ -42,7 +42,7 @@ class EmailOverrideInterceptorModel extends AbstractInterceptorModel {
 
     $conditionBlocks = [];
 
-    foreach ($settings ?? [] as $conditionBlock) {
+    foreach ($settings as $conditionBlock) {
       if (!isset($conditionBlock['conditions']) || (!isset($conditionBlock['isTrue']) && !isset($conditionBlock['else']))) {
         continue;
       }

--- a/Classes/Finisher/MailFinisher.php
+++ b/Classes/Finisher/MailFinisher.php
@@ -370,7 +370,7 @@ class MailFinisher extends AbstractFinisher implements LoggerAwareInterface {
       $mailer = GeneralUtility::makeInstance(Mailer::class);
       $mailer->send($beforeSendEvent->getEmailObject());
     } catch (\Exception $e) {
-      $this->logger->error($e->getMessage());
+      $this->logger?->error($e->getMessage());
 
       $this->formConfig->debugMessage('Mailfinisher Error', [$e->getMessage()], Severity::Error);
     }

--- a/Classes/Interceptor/EmailOverrideInterceptor.php
+++ b/Classes/Interceptor/EmailOverrideInterceptor.php
@@ -25,10 +25,12 @@ use Typoheads\Formhandler\Utility\Utility;
 class EmailOverrideInterceptor extends AbstractInterceptor implements LoggerAwareInterface {
   use LoggerAwareTrait;
 
+  /** @var array{toEmail: string, subject: string, senderEmail: string, senderName: string, replyToEmail: string, replyToName: string, ccEmail: string, ccName: string, bccEmail: string, bccName: string, returnPath: string, templateMailHtml: string, templateMailText: string, attachments: array<string, array{fileOrField: string, mime: null|string, renameTo: null|string}>, embedFiles: array<string, array{fileOrField: string, mime: null|string, renameTo: null|string}>} */
   protected array $adminMailConfig;
 
   protected bool $returns;
 
+  /** @var array{toEmail: string, subject: string, senderEmail: string, senderName: string, replyToEmail: string, replyToName: string, ccEmail: string, ccName: string, bccEmail: string, bccName: string, returnPath: string, templateMailHtml: string, templateMailText: string, attachments: array<string, array{fileOrField: string, mime: null|string, renameTo: null|string}>, embedFiles: array<string, array{fileOrField: string, mime: null|string, renameTo: null|string}>} */
   protected array $userMailConfig;
 
   protected Utility $utility;
@@ -49,9 +51,9 @@ class EmailOverrideInterceptor extends AbstractInterceptor implements LoggerAwar
      */
     $allMailFinisherConfigs = array_filter($formConfig->finishers, function ($finisher) {
       return $finisher instanceof MailFinisherModel;
-    }) ?? false;
+    });
 
-    if (false === $allMailFinisherConfigs) {
+    if (empty($allMailFinisherConfigs)) {
       return false;
     }
 
@@ -87,7 +89,7 @@ class EmailOverrideInterceptor extends AbstractInterceptor implements LoggerAwar
       // results from array_filter keep their original keys. Use that key to override the config
       $formConfig->finishers[key($allMailFinisherConfigs)] = $this->createNewMailConfig();
     } catch (\Exception $e) {
-      $this->logger->error($e->getMessage());
+      $this->logger?->error($e->getMessage());
 
       $formConfig->debugMessage('Mailfinisher Error', [$e->getMessage()], Severity::Error);
 
@@ -97,7 +99,7 @@ class EmailOverrideInterceptor extends AbstractInterceptor implements LoggerAwar
     return true;
   }
 
-  protected function createNewMailConfig() {
+  protected function createNewMailConfig(): MailFinisherModel {
     return GeneralUtility::makeInstance(
       MailFinisherModel::class,
       ['returns' => $this->returns],
@@ -106,7 +108,10 @@ class EmailOverrideInterceptor extends AbstractInterceptor implements LoggerAwar
     );
   }
 
-  protected function handleOverride(string $configToAffect, $overrideConfig) {
+  /**
+   * @param array<string, string> $overrideConfig
+   */
+  protected function handleOverride(string $configToAffect, array $overrideConfig): void {
     $configToAffect = &$this->{$configToAffect.'MailConfig'} ?? false;
 
     if (false === $configToAffect) {

--- a/Classes/Interceptor/EmailOverrideInterceptor.php
+++ b/Classes/Interceptor/EmailOverrideInterceptor.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of TYPO3 CMS-based extension "Formhandler" by JAKOTA.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ */
+
+namespace Typoheads\Formhandler\Interceptor;
+
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use Typoheads\Formhandler\Definitions\Severity;
+use Typoheads\Formhandler\Domain\Model\Config\Finisher\MailFinisherModel;
+use Typoheads\Formhandler\Domain\Model\Config\FormModel;
+use Typoheads\Formhandler\Domain\Model\Config\Interceptor\AbstractInterceptorModel;
+use Typoheads\Formhandler\Domain\Model\Config\Interceptor\EmailOverrideInterceptorModel;
+use Typoheads\Formhandler\Utility\Utility;
+
+class EmailOverrideInterceptor extends AbstractInterceptor implements LoggerAwareInterface {
+  use LoggerAwareTrait;
+
+  protected array $adminMailConfig;
+
+  protected bool $returns;
+
+  protected array $userMailConfig;
+
+  protected Utility $utility;
+
+  public function __construct() {
+    $this->utility = GeneralUtility::makeInstance(Utility::class);
+  }
+
+  public function process(FormModel &$formConfig, AbstractInterceptorModel &$interceptorConfig): bool {
+    if (!$interceptorConfig instanceof EmailOverrideInterceptorModel) {
+      return false;
+    }
+
+    /**
+     * find finisher config by Classname.
+     *
+     * @var array<int, MailFinisherModel> $allMailFinisherConfigs
+     */
+    $allMailFinisherConfigs = array_filter($formConfig->finishers, function ($finisher) {
+      return $finisher instanceof MailFinisherModel;
+    }) ?? false;
+
+    if (false === $allMailFinisherConfigs) {
+      return false;
+    }
+
+    $currentFinisherConfig = current($allMailFinisherConfigs);
+
+    $this->adminMailConfig = $currentFinisherConfig->adminMailConfig;
+    $this->userMailConfig = $currentFinisherConfig->userMailConfig;
+    $this->returns = $currentFinisherConfig->returns;
+
+    try {
+      foreach ($interceptorConfig->conditonBlocks as $conditionBlock) {
+        $evaluation = $this->utility->conditionEvaluate($conditionBlock, $formConfig);
+
+        if ($evaluation) {
+          foreach ($conditionBlock->isTrue as $emailConfigToAffect => $valuesToSet) {
+            if (empty($valuesToSet) || ('admin' !== $emailConfigToAffect && 'user' !== $emailConfigToAffect)) {
+              continue;
+            }
+
+            $this->handleOverride($emailConfigToAffect, $valuesToSet);
+          }
+        } else {
+          foreach ($conditionBlock->else as $emailConfigToAffect => $valuesToSet) {
+            if (empty($valuesToSet) || ('admin' !== $emailConfigToAffect && 'user' !== $emailConfigToAffect)) {
+              continue;
+            }
+
+            $this->handleOverride($emailConfigToAffect, $valuesToSet);
+          }
+        }
+      }
+
+      // results from array_filter keep their original keys. Use that key to override the config
+      $formConfig->finishers[key($allMailFinisherConfigs)] = $this->createNewMailConfig();
+    } catch (\Exception $e) {
+      $this->logger->error($e->getMessage());
+
+      $formConfig->debugMessage('Mailfinisher Error', [$e->getMessage()], Severity::Error);
+
+      return false;
+    }
+
+    return true;
+  }
+
+  protected function createNewMailConfig() {
+    return GeneralUtility::makeInstance(
+      MailFinisherModel::class,
+      ['returns' => $this->returns],
+      $this->adminMailConfig,
+      $this->userMailConfig,
+    );
+  }
+
+  protected function handleOverride(string $configToAffect, $overrideConfig) {
+    $configToAffect = &$this->{$configToAffect.'MailConfig'} ?? false;
+
+    if (false === $configToAffect) {
+      return;
+    }
+
+    foreach ($overrideConfig as $fieldToOverride => $valueToSet) {
+      if (array_key_exists($fieldToOverride, $configToAffect)) {
+        $configToAffect[$fieldToOverride] = strval($valueToSet);
+      }
+    }
+  }
+}


### PR DESCRIPTION
This MR adds a new Interceptor used to override email settings using conditions similar to the allready existing conditonBlocks.

Below is a example config for the new Interceptor.
```
  saveInterceptors {
    EmailOverride {
      model = EmailOverrideInterceptor
      config {
        1 {
          conditions.OR1.AND1 = 1.field.select = firstValue
          isTrue {
            admin {
              senderEmail = firstEmail@domain.tld
            }
          }
          isTrue {
            test {
              senderEmail = secondEmail@domain.tld
            }
          }
        }
      }
    }
  }
```